### PR TITLE
feat: add ability to gen cli completion scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "async-trait",
  "base64",
  "clap",
+ "clap_complete",
  "prettytable-rs",
  "reqwest",
  "serde",
@@ -178,6 +179,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { version = "0.12.15", features = ["json", "blocking"] }
 tokio = { version = "1.0", features = ["full"] }
 base64 = "0.22.1"
 clap = { version = "4.5.35", features = ["derive"] }
+clap_complete = "4.5.47"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 prettytable-rs = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,10 @@ mod protocols;
 
 use std::error::Error;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use protocols::{ApiProtocol, ApiResponse, Protocol};
+use std::io;
 
 #[derive(Parser)]
 #[command(name = "apigrok")]
@@ -15,6 +17,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Fetch the content available at a specified url
     Fetch {
         url: String,
 
@@ -30,6 +33,11 @@ enum Commands {
 
         #[arg(short, long, value_enum)]
         protocol: Option<Protocol>,
+    },
+    /// Generate autocompletion scripts for various shells
+    Completion {
+        /// The shell for which autocompletion should be generated (e.g. bash)
+        shell: Shell,
     },
 }
 
@@ -57,6 +65,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             input: _,
             protocol: _,
         } => {}
+        Commands::Completion { shell } => {
+            let command = &mut Cli::command();
+            generate(
+                shell,
+                command,
+                command.get_name().to_string(),
+                &mut io::stdout(),
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
E.g. with this change... `eval "$(cargo run completion bash)"` in a bash shell will configure tab-completion with the various params/args. This uses [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/) and just hooks into the same stuff that's already configured in clap.