### PR TITLE
feat: add selection of verbose output content

### DIFF
--- a/src/protocols/http.rs
+++ b/src/protocols/http.rs
@@ -1,5 +1,7 @@
-use super::*;
-use reqwest::Client;
+use crate::protocols::{ApiProtocol, ApiRequest, ApiResponse, Protocol};
+use async_trait::async_trait;
+use reqwest::{Client, Version};
+use std::error::Error;
 use std::time::Instant;
 
 pub struct HttpClient {
@@ -14,7 +16,7 @@ pub enum HttpVersion {
 
 #[async_trait]
 impl ApiProtocol for HttpClient {
-    async fn fetch(&self, url: &str) -> Result<ApiResponse, Box<dyn Error>> {
+    async fn fetch(&self, url: &str) -> Result<(ApiRequest, ApiResponse), Box<dyn Error>> {
         let client = match self.version {
             HttpVersion::Http1 => Client::builder().http1_only().build()?,
             // HttpVersion::Http2 => Client::builder().http2_prior_knowledge().build()?,
@@ -24,7 +26,19 @@ impl ApiProtocol for HttpClient {
         };
 
         let start = Instant::now();
-        let response = client.get(url).send().await?;
+
+        let request = client.get(url).build()?;
+        let request_headers: Vec<(String, String)> = request
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+            .collect();
+
+        let request_version = format!("{:?}", &request.version());
+        let request_path = (&request.url().path()).to_string();
+
+        let response = client.execute(request).await?;
+
         let path = response.url().path().to_string();
         let duration = start.elapsed();
         let status = response.status().as_u16();
@@ -38,20 +52,28 @@ impl ApiProtocol for HttpClient {
 
         let body = response.bytes().await?.to_vec();
 
-        Ok(ApiResponse {
-            path: path,
-            protocol: match self.version {
-                HttpVersion::Http1 => Protocol::Http1,
-                // HttpVersion::Http2 => Protocol::Http2,
-                // HttpVersion::Http3 => Protocol::Http3,
+        Ok((
+            ApiRequest {
+                headers: Some(request_headers),
+                method: "GET".to_string(),
+                path: request_path,
+                version: request_version,
             },
-            status: Some(status),
-            headers: Some(headers),
-            body: Some(body),
-            version: format!("{}", version_to_string(version)),
-            ip: ip,
-            duration: duration,
-        })
+            ApiResponse {
+                path: path,
+                protocol: match self.version {
+                    HttpVersion::Http1 => Protocol::Http1,
+                    // HttpVersion::Http2 => Protocol::Http2,
+                    // HttpVersion::Http3 => Protocol::Http3,
+                },
+                status: Some(status),
+                headers: Some(headers),
+                body: Some(body),
+                version: format!("{}", version_to_string(version)),
+                ip: ip,
+                duration: duration,
+            },
+        ))
     }
 }
 

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -7,9 +7,8 @@ use base64::{Engine, engine::general_purpose};
 use clap::ValueEnum;
 use encoding_rs::{Encoding, UTF_8};
 use mime::Mime;
-use reqwest::Version;
 use serde::{Deserialize, Serialize};
-use std::{error::Error, net::SocketAddr};
+use std::net::SocketAddr;
 
 #[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
 pub enum Protocol {
@@ -22,7 +21,10 @@ pub enum Protocol {
 
 #[async_trait]
 pub trait ApiProtocol {
-    async fn fetch(&self, url: &str) -> Result<ApiResponse, Box<dyn std::error::Error>>;
+    async fn fetch(
+        &self,
+        url: &str,
+    ) -> Result<(ApiRequest, ApiResponse), Box<dyn std::error::Error>>;
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,6 +37,14 @@ pub struct ApiResponse {
     pub version: String,
     pub ip: Option<SocketAddr>,
     pub duration: std::time::Duration,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiRequest {
+    pub headers: Option<Vec<(String, String)>>,
+    pub method: String,
+    pub path: String,
+    pub version: String,
 }
 
 impl ApiResponse {


### PR DESCRIPTION
E.g. explicitly include the metadata for both request & response:

```bash
cargo run -- fetch --verbose verbose --verbose-detail request-details --verbose-detail response-details https://example.com
```

Note that the lack of header output is kind of a lie; not sure we can access the low level info in reqwest :scream_cat: 