### PR TITLE
chore: tidy up macro namespacing

### DIFF
--- a/src/color/mod.rs
+++ b/src/color/mod.rs
@@ -1,3 +1,19 @@
+macro_rules! request_output {
+    ($expression:block) => {
+        use ansi_term::Color::Yellow;
+        $crate::color::color_output!(Yellow, $expression)
+    };
+}
+pub(crate) use request_output;
+
+macro_rules! response_output {
+    ($expression:block) => {
+        use ansi_term::Color::Cyan;
+        $crate::color::color_output!(Cyan, $expression)
+    };
+}
+pub(crate) use response_output;
+
 macro_rules! color_output {
     ($color:expr, $expression:block) => {
         use io::stdout;
@@ -13,22 +29,4 @@ macro_rules! color_output {
         }
     };
 }
-
 pub(crate) use color_output;
-
-macro_rules! request_output {
-    ($expression:block) => {
-        use ansi_term::Color::Yellow;
-        color_output!(Yellow, $expression)
-    };
-}
-
-macro_rules! response_output {
-    ($expression:block) => {
-        use ansi_term::Color::Cyan;
-        color_output!(Cyan, $expression)
-    };
-}
-
-pub(crate) use request_output;
-pub(crate) use response_output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 mod color;
 mod protocols;
 
-use crate::color::{color_output, request_output, response_output};
+use crate::color::request_output;
+use crate::color::response_output;
 use crate::protocols::ApiRequest;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};


### PR DESCRIPTION
No longer requires an explicit `use` of the nested `color_output` macro where the `request_output` and `response_output` macros are used.